### PR TITLE
Project tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib/
+node_modules/

--- a/src/HistoryExporterService.coffee
+++ b/src/HistoryExporterService.coffee
@@ -4,27 +4,24 @@ logger      = require('logger')
 config      = require('config')
 fileService = require('FileService')
 Promise     = require('bluebird')
-tracker     = require('Tracker')
 
 
 class HistoryExporterService
 
-  constructor: (fileName,projectId) ->
-    @fileName = fileName
-    @projectId = projectId
+  constructor: (@fileName, @projectId, @tracker) ->
     @excelMicroserviceEndpoint = config.get('weaver-plugin-history-exporter.services.excelMicroservice')
     @sheet = {0:{0:{}}}
     @dir = 'uploads'
     logger.code.debug("#{config.get('weaver-plugin-history-exporter.services.excelMicroservice')}")
-    logger.code.debug(fileName)
-    logger.code.debug(projectId)
+    logger.code.debug(@fileName)
+    logger.code.debug(@projectId)
 
   excelDumpAll: ->
     try
       promises = []
       request.payload = {}
       # request.payload.limit = 100 # just to not break everithing
-      tracker.getHistoryFor(request)
+      @tracker.getHistoryFor(request)
       .then((rows) =>
         promises.push(@extractHeaders(rows[0]))
         promises.push(@extractData(rows))

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,7 +2,7 @@ HistoryExporterService = require('./HistoryExporterService')
 
 module.exports = (bus) ->
 
-  bus.private('reportExcelDumpAll').require('fileName','projectId').on((req, fileName, projectId) ->
-    historyExporterService = new HistoryExporterService(fileName, projectId)
+  bus.private('reportExcelDumpAll').retrieve('tracker').require('fileName','projectId').on((req, tracker, fileName, projectId) ->
+    historyExporterService = new HistoryExporterService(fileName, projectId, tracker)
     historyExporterService.excelDumpAll()
   )

--- a/test/HistoryReport.test.coffee
+++ b/test/HistoryReport.test.coffee
@@ -8,7 +8,8 @@ describe 'BB reporting pluging testing', ->
 
   it 'should list available plugins', ->
     Weaver.Plugin.list().then((plugins) ->
-      assert.equal(plugins.length, 4)
+      plugin = i for i in plugins when i._name is 'weaver-plugin-history-exporter'
+      expect(plugin).to.not.be.undefined
     )
 
   it 'should get a weaver-plugin-history-exporter plugin', ->


### PR DESCRIPTION
Use the tracker defined per project instead of the singleton one previously used.